### PR TITLE
Wait for request to finish before switching scene

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/Scenes/GameOver/GameOver.gd
+++ b/Scenes/GameOver/GameOver.gd
@@ -44,7 +44,10 @@ func go_to_title():
 func _on_HighscoreBtn_pressed():
 	var secretkey = 'OURSECRETKEYHERE'
 	var url = "http://dreamlo.com/lb/" + secretkey + "/add/" + $"HBoxContainer/HighscoreName".text + "/" + str($"../HUD".score)
-	$HTTPRequest.request(url)
+	var error = $HTTPRequest.request(url)
+	if error != OK:
+		push_error("An error occurred in the HTTP request, result was " + str(error))
+		
 
 
 func _on_request_completed(result, response_code, headers, body):

--- a/Scenes/GameOver/GameOver.gd
+++ b/Scenes/GameOver/GameOver.gd
@@ -6,6 +6,7 @@ var is_game_over = false
 
 func _ready():
 	refresh();
+	$HTTPRequest.connect("request_completed", self, "_on_request_completed")
 
 func _input(event):
 	if is_game_over:
@@ -44,4 +45,7 @@ func _on_HighscoreBtn_pressed():
 	var secretkey = 'OURSECRETKEYHERE'
 	var url = "http://dreamlo.com/lb/" + secretkey + "/add/" + $"HBoxContainer/HighscoreName".text + "/" + str($"../HUD".score)
 	$HTTPRequest.request(url)
+
+
+func _on_request_completed(result, response_code, headers, body):
 	go_to_title()

--- a/Scenes/GameOver/GameOver.gd
+++ b/Scenes/GameOver/GameOver.gd
@@ -49,3 +49,7 @@ func _on_HighscoreBtn_pressed():
 
 func _on_request_completed(result, response_code, headers, body):
 	go_to_title()
+
+
+func _on_HighscoreName_focus_entered():
+	$"Timer".stop();

--- a/Scenes/GameOver/GameOver.tscn
+++ b/Scenes/GameOver/GameOver.tscn
@@ -124,4 +124,5 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 [connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]
+[connection signal="focus_entered" from="HBoxContainer/HighscoreName" to="." method="_on_HighscoreName_focus_entered"]
 [connection signal="pressed" from="HBoxContainer/HighscoreBtn" to="." method="_on_HighscoreBtn_pressed"]


### PR DESCRIPTION
The highscore was sometimes submitted but most of the times it was not.
It seems like switching the scene cancels the request so we're switching
the scene after the request has finished.