### PR TITLE
save highscore name in lowertext

### DIFF
--- a/Scenes/GameOver/GameOver.gd
+++ b/Scenes/GameOver/GameOver.gd
@@ -43,7 +43,7 @@ func go_to_title():
 
 func _on_HighscoreBtn_pressed():
 	var secretkey = 'OURSECRETKEYHERE'
-	var url = "https://tcv8.de/lb/" + secretkey + "/add/" + $"HBoxContainer/HighscoreName".text + "/" + str($"../HUD".score)
+	var url = "https://tcv8.de/lb/" + secretkey + "/add/" + $"HBoxContainer/HighscoreName".text.to_lower() + "/" + str($"../HUD".score)
 	var error = $HTTPRequest.request(url)
 	if error != OK:
 		push_error("An error occurred in the HTTP request, result was " + str(error))


### PR DESCRIPTION
Closes #24 

Please just test it before merging. Couldn‘t test it. But it absolutely should work.
Saving all Highscore names in lowercase seems to be the best way to go for me. Because of our font they will be displayed in uppercase anyway and in a database a key like object in lowercase is much more natural than one in uppercase.